### PR TITLE
Updates request dependency to 2.81. Adds 'followOriginalHttpMethod' option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = function(options, cb) {
 
   options.method = 'HEAD'
   options.followAllRedirects = true
+  options.followOriginalHttpMethod = true
 
   request(options, function(err, res, body) {
     if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "help": "~2.1.0",
     "noptd": "~2.0.0",
     "pretty-bytes": "~2.0.1",
-    "request": "~2.57.0"
+    "request": "~2.81.0"
   },
   "devDependencies": {
     "tap": "~2.2.0"


### PR DESCRIPTION
When setting `followAllRedirects` to `true` the following requests are executed as "GET" requests. To force the redirect to use the original http method, the `followOriginalHttpMethod` option needs to be set to true as well ([issue](https://github.com/request/request/pull/2435)).